### PR TITLE
Social Assistance updates

### DIFF
--- a/srd/assistance/params/assistance_2021.csv
+++ b/srd/assistance/params/assistance_2021.csv
@@ -1,0 +1,21 @@
+variable;value;type;definition;source;comments
+socass_qc_assets_couple;2500;float;;http://legisquebec.gouv.qc.ca/fr/pdf/cr/A-13.1.1,%20R.%201.pdf; liquid assets not considered
+socass_qc_assets_single;1500;float;;;
+socass_qc_base_single;8496;float;;;
+socass_qc_base_couple;12864;float;;;
+socass_qc_reductionrate;1;float;;; ################## + contraintes temporaires ???
+socass_qc_exemption_single;2400;float;;;
+socass_qc_exemption_couple;3600;float;;https://cdn-contenu.quebec.ca/cdn-contenu/adm/min/travail-emploi-solidarite-sociale/publications-adm/autres/FI_indexation_aide_sociale_VF.pdf?1576871495;
+socass_on_assets_couple;10000;float;;https://www.mcss.gov.on.ca/en/mcss/programs/social/directives/index.aspx;#ZBO didn't change since 2017
+socass_on_assets_single;15000;float;;;didn't change since 2017
+socass_on_assets_kid;500;float;;;didn't change since 2017
+socass_on_exempt;2400;float;;;
+socass_on_exempt_rate;0.5;float;;;
+socass_on_couple_no_dep18;5928;float;;https://www.ontario.ca/laws/regulation/980134/v107;Les montans non pas changer depuis 2019
+socass_on_couple_1dep18;7824;float;;;
+socass_on_couple_2dep18;9912;float;;;
+socass_on_add_dep18;175;float;;;
+socass_on_single_no_dep18_kid;4116;float;;;
+socass_on_single_no_dep18;4320;float;;;
+socass_on_single_1dep18;7476;float;;;
+socass_on_single_2dep18;9372;float;;;

--- a/srd/assistance/programs.py
+++ b/srd/assistance/programs.py
@@ -29,6 +29,8 @@ def program(year):
         p = program_2019()
     if year == 2020:
         p = program_2020()
+    if year == 2021:
+        p = program_2021()
     return p
 
 
@@ -86,4 +88,17 @@ class program_2020(template):
     def __init__(self):
         add_params_as_attr(self, module_dir + '/assistance/params/assistance_2020.csv')
         self.fed = federal.form(2020)
+        return
+
+
+# program for 2021, derived from template, only requires modify
+# functions that change
+class program_2021(template):
+    """
+    Version du programme de 2021.
+    """
+
+    def __init__(self):
+        add_params_as_attr(self, module_dir + "/assistance/params/assistance_2021.csv")
+        self.fed = federal.form(2021)
         return


### PR DESCRIPTION
Les montants non pas changés depuis 2019
https://www.ontario.ca/laws/statute/97o25a?search=Ontario+Works+Act

Je me demande si on devrait modifier les montants de 2020 qui ont été index dans SRD alors qu’ils n’ont pas changé.